### PR TITLE
Compiler werror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ include_directories(${Boost_INCLUDE_DIRS})
 
 add_compile_options(-Wall -Wextra -pedantic)
 
+# treat all warnings as errors
+add_compile_options(-Werror)
+
 # uncomment to enable verbose debug output
 # add_compile_definitions(CROSSING_CONSOLES_DO_DEBUG)
 

--- a/src/communication/connection_layer/connection/Connection.cpp
+++ b/src/communication/connection_layer/connection/Connection.cpp
@@ -294,10 +294,10 @@ Connection::Connection(std::shared_ptr<message_layer::MessageInputStream> messag
                        std::shared_ptr<message_layer::MessageOutputStream> message_output_stream,
                        ConnectionState connection_state, sequence_t sequence_counter, timeout_t timeout)
     : state(connection_state)
-    , sequence_counter(sequence_counter)
     , timeout(timeout)
     , message_input_stream(std::move(message_input_stream))
-    , message_output_stream(std::move(message_output_stream)) {
+    , message_output_stream(std::move(message_output_stream))
+    , sequence_counter(sequence_counter) {
   resend_interval =
       std::chrono::duration_cast<std::chrono::milliseconds>(timeout / ProtocolDefinition::resend_denominator);
   timestamp_last_change = std::chrono::steady_clock::now();

--- a/src/communication/message_layer/message_stream/MessageCoder.cpp
+++ b/src/communication/message_layer/message_stream/MessageCoder.cpp
@@ -71,9 +71,9 @@ std::vector<uint8_t> MessageCoder::Encode(Message *message) {
   WriteToStream(output, ProtocolDefinition::flag, sizeof(ProtocolDefinition::flag), false);
 
   // MessageType is never equal to a special value
-  assert(static_cast<const unsigned char>(message->GetMessageType()) != ProtocolDefinition::flag);
-  assert(static_cast<const unsigned char>(message->GetMessageType()) != ProtocolDefinition::escape);
-  assert(static_cast<const unsigned char>(message->GetMessageType()) != ProtocolDefinition::end_marker);
+  assert(static_cast<unsigned char>(message->GetMessageType()) != ProtocolDefinition::flag);
+  assert(static_cast<unsigned char>(message->GetMessageType()) != ProtocolDefinition::escape);
+  assert(static_cast<unsigned char>(message->GetMessageType()) != ProtocolDefinition::end_marker);
 
   output.push_back(static_cast<uint8_t>(message->GetMessageType()));
 

--- a/src/game/networking/Change.cpp
+++ b/src/game/networking/Change.cpp
@@ -14,7 +14,7 @@ Change::Change(ChangeType change_type)
 Change::Change(std::vector<uint8_t> bytes)
     : payload(bytes) {
   auto raw_change_type = bytes[0];
-  assert(raw_change_type >= 0 && raw_change_type <= (uint8_t)ChangeType::HIGHEST_ELEMENT);
+  assert(raw_change_type <= (uint8_t)ChangeType::HIGHEST_ELEMENT);
   change_type = static_cast<ChangeType>(raw_change_type);
 }
 

--- a/src/game/networking/SerializationUtils.h
+++ b/src/game/networking/SerializationUtils.h
@@ -16,7 +16,7 @@ class SerializationUtils {
    */
   template <class T>
   static void SerializeObject(const T &object, std::vector<uint8_t> &output_vector) {
-    for (int i = 0; i < sizeof(T); ++i) {
+    for (unsigned int i = 0; i < sizeof(T); ++i) {
       const uint8_t &byte = *(reinterpret_cast<const uint8_t *>(&object) + i);
 
       output_vector.push_back(byte);
@@ -30,7 +30,7 @@ class SerializationUtils {
   template <class T>
   static const T &DeserializeObject(std::vector<uint8_t>::iterator &input_iterator) {
     T &object = *(reinterpret_cast<T *>(&(*input_iterator)));
-    for (int i = 0; i < sizeof(T); ++i) {
+    for (unsigned int i = 0; i < sizeof(T); ++i) {
       input_iterator++;
     }
     return object;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,8 @@ add_executable(crossing_consoles_test
         game_logic.cpp
         game_projectile.cpp
         fixtures/GamePlay.cpp
+
+        utils/detect_debugger.cpp
         )
 
 target_link_libraries(crossing_consoles_test crossing_consoles_lib)

--- a/tests/connection_manager.cpp
+++ b/tests/connection_manager.cpp
@@ -21,6 +21,7 @@ using namespace communication::message_layer;
 bool CAUGHT_SIGNAL_BROKEN_PIPE = false;
 
 static void broken_pipe_handler(int signum) {
+  assert(signum == SIGPIPE);
   // Received signal of type SIGPIPE (Broken pipe)
   CAUGHT_SIGNAL_BROKEN_PIPE = true;
 }

--- a/tests/utils/detect_debugger.cpp
+++ b/tests/utils/detect_debugger.cpp
@@ -1,0 +1,36 @@
+#ifndef _WIN32
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cctype>
+#include <cstring>
+
+// Detect debugger as described in https://stackoverflow.com/a/24969863
+bool runningUnderDebugger() {
+  char buf[4096];
+
+  const int status_fd = ::open("/proc/self/status", O_RDONLY);
+  if (status_fd == -1)
+    return false;
+
+  const ssize_t num_read = ::read(status_fd, buf, sizeof(buf) - 1);
+  if (num_read <= 0)
+    return false;
+
+  buf[num_read] = '\0';
+  constexpr char tracerPidString[] = "TracerPid:";
+  const auto tracer_pid_ptr = ::strstr(buf, tracerPidString);
+  if (!tracer_pid_ptr)
+    return false;
+
+  for (const char *characterPtr = tracer_pid_ptr + sizeof(tracerPidString) - 1; characterPtr <= buf + num_read;
+       ++characterPtr) {
+    if (::isspace(*characterPtr))
+      continue;
+    else
+      return ::isdigit(*characterPtr) != 0 && *characterPtr != '0';
+  }
+
+  return false;
+}
+#endif

--- a/tests/utils/detect_debugger.h
+++ b/tests/utils/detect_debugger.h
@@ -8,34 +8,8 @@
 #include <cctype>
 #include <cstring>
 
-// Detect debugger as described in https://stackoverflow.com/a/24969863
-static bool runningUnderDebugger() {
-  char buf[4096];
-
-  const int status_fd = ::open("/proc/self/status", O_RDONLY);
-  if (status_fd == -1)
-    return false;
-
-  const ssize_t num_read = ::read(status_fd, buf, sizeof(buf) - 1);
-  if (num_read <= 0)
-    return false;
-
-  buf[num_read] = '\0';
-  constexpr char tracerPidString[] = "TracerPid:";
-  const auto tracer_pid_ptr = ::strstr(buf, tracerPidString);
-  if (!tracer_pid_ptr)
-    return false;
-
-  for (const char *characterPtr = tracer_pid_ptr + sizeof(tracerPidString) - 1; characterPtr <= buf + num_read;
-       ++characterPtr) {
-    if (::isspace(*characterPtr))
-      continue;
-    else
-      return ::isdigit(*characterPtr) != 0 && *characterPtr != '0';
-  }
-
-  return false;
-}
+/// Detect a debugger as described in https://stackoverflow.com/a/24969863
+bool runningUnderDebugger();
 #endif
 
 #endif  // CROSSING_CONSOLES_DETECT_DEBUGGER_H


### PR DESCRIPTION
@AnneRei @Martina-Scheffler @julian-fuchs 
This pr enables the `-Werror`compiler flag. This means that the pipeline will fail if the compiler throws any warnings. Locally this can be disabled by commenting out line 13 in the top level CMakeList. 

Keep in mind that this might result in errors when merging older branches as they might contain warnings which will know be counted as errors.